### PR TITLE
solidity-sha3 babel preset env

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,3 @@
 {
-  "presets": ['es2015']
+  "presets": ['env']
 }

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "babel-cli": "*",
-    "babel-preset-es2015": "*",
+    "babel-preset-env": "^1.6.1",
     "babel-register": "*",
     "left-pad": "^1.1.1",
     "web3": "^0.16.0"


### PR DESCRIPTION
babel-preset-es2015@6.24.1 is deprecated. This makes packages depending on solidity-sha3 raise a warning with a suggestion to use babel-preset-env.

This pull request migrates to the currently suggested babel-preset-env which replaces many presets that were previously used, including babel-preset-es2015.